### PR TITLE
Add id and filename tokens to use in openframe-processing extension

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -329,10 +329,12 @@ fc.changeArtwork = function() {
             parsed = url.parse(new_artwork.url);
             file_name = path.basename(parsed.pathname);
 
-            downloader.downloadFile(new_artwork.url, new_artwork.id + file_name)
+            downloader.downloadFile(new_artwork.url, new_artwork.id + file_name, file_name)
                 .then(function(filePath) {
                     tokens['$filepath'] = filePath;
                     tokens['$url'] = new_artwork.url;
+                    tokens['$id'] = new_artwork.id;
+                    tokens['$filename'] = file_name;
                     swapArt();
                 })
                 .catch(reject);


### PR DESCRIPTION
Hello, first thank you very much for this fantastic project.
The request pull it to see if it seems right to add two new tokens:

```javascript
   tokens [ $id] = new_artwork.id;
   tokens [ $filename] = file_name;
```

I'm working on the extension [openFrame-processing](https://www.npmjs.com/package/openframe-processing) and processing-java client needs a directory to run the command. With these two tokens I can create files and directory / tmp easily.

I said thank you very much for the work