### PR TITLE
extension-manager: fixed tests & variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The block diagram below represents a proposed architecture for the Openframe pla
 
 * `controller.js` - manages the actions around controlling the frame (changing artwork, updating settings, etc.)
 * `process-manager.js` - manages starting and stopping processes for displaying artworks
-* `plugin-manager.js` - manages installing and initializing plugins (aka extensions)
+* `extensions-manager.js` - manages installing and initializing extensions (aka plugins)
 * `frame.js` - a wrapper for the Frame model, which gets persisted to
 * `user.js` - a wrapper for the User model
 * `pubsub.js` - creates and manages connection to global event system

--- a/src/controller.js
+++ b/src/controller.js
@@ -11,7 +11,7 @@ var url = require('url'),
     downloader = require('./downloader'),
     pubsub = require('./pubsub'),
     proc_man = require('./process-manager'),
-    pm = require('./extension-manager'),
+    ext_man = require('./extension-manager'),
     config = require('./config'),
     frame = require('./frame'),
     user = require('./user'),
@@ -68,7 +68,7 @@ fc.installExtension = function(extension) {
         .then(function() {
             frame.fetch()
                 .then(function() {
-                    pm.installExtension(packageName, version, true)
+                    ext_man.installExtension(packageName, version, true)
                         .then(function() {
                             debug('Installed ' + extension + ' successfully, saving frame...');
                             var ext = require(packageName);
@@ -111,7 +111,7 @@ fc.uninstallExtension = function(packageName) {
         .then(function() {
             frame.fetch()
                 .then(function() {
-                    pm.uninstallExtension(packageName)
+                    ext_man.uninstallExtension(packageName)
                         .then(function() {
                             debug('Uninstalled ' + packageName + ' successfully, saving frame...');
                             // successfully installed extension locally, add to frame
@@ -225,7 +225,7 @@ fc.connect = function(userId) {
             .then(function() {
                 debug('ready to init...');
                 // initExtensions now always resolves, is never rejected
-                return pm.initExtensions(frame.state.extensions, fc.extensionApi);
+                return ext_man.initExtensions(frame.state.extensions, fc.extensionApi);
             })
             .then(readyToConnect)
             .catch(function(err) {
@@ -262,10 +262,10 @@ fc.registerNewFrame = function(userId) {
             debug(data.obj);
             frame.state = data.obj;
             frame.persistStateToFile();
-            pm.installExtensions(frame.state.extensions)
+            ext_man.installExtensions(frame.state.extensions)
                 .then(function() {
                     debug('-----> extensions installed');
-                    pm.initExtensions(frame.state.extensions, fc.extensionApi)
+                    ext_man.initExtensions(frame.state.extensions, fc.extensionApi)
                         .then(function() {
                             resolve(frame.state);
                         });

--- a/src/extension-manager.js
+++ b/src/extension-manager.js
@@ -105,14 +105,14 @@ function _installExtension(package_name, version, force) {
 ext_man.installExtension = _installExtension;
 
 /**
- * Rext_manoves a single extensions by rext_manoving it from the npm package.
+ * Removes a single extensions by removing it from the npm package.
  *
  * @param  {String} package_name NPM package name
  * @return {Promise} A promise resolving with the package_name
  */
-function _rext_manoveExtension(package_name) {
-    debug('rext_manoveExtension', package_name);
-    var cmd = 'npm rext_manove -g ' + package_name;
+function _removeExtension(package_name) {
+    debug('removeExtension', package_name);
+    var cmd = 'npm remove -g ' + package_name;
     cmd += ' --save';
     return new Promise((resolve, reject) => {
         _runNpmCommand(cmd).then(function() {
@@ -122,7 +122,7 @@ function _rext_manoveExtension(package_name) {
 }
 
 // public exposure
-ext_man.uninstallExtension = _rext_manoveExtension;
+ext_man.uninstallExtension = _removeExtension;
 
 /**
  * Check whether a extension is already installed.
@@ -176,7 +176,7 @@ function _initExtension(extensions_name, ofExtensionApi) {
             extensions._init(ofExtensionApi);
             resolve(extensions);
         } catch (e) {
-            // problext_man trying to require extensions
+            // problem trying to require extensions
             debug('ERROR - ', e);
             reject(e);
         }

--- a/src/extension-manager.js
+++ b/src/extension-manager.js
@@ -4,18 +4,7 @@ var debug = require('debug')('openframe:extensions_manager'),
 
     config = require('./config'),
 
-    em = module.exports = {};
-
-/**
- * Initialize extensions module
- *
- * TODO: UNUSED - delete me?
- *
- * @param  {Object} ofrc config object
- */
-em.init = function() {
-    debug('init');
-};
+    ext_man = module.exports = {};
 
 /**
  * Install extensions.
@@ -27,7 +16,7 @@ em.init = function() {
  * @param {Boolean} force Install the extensions even if it's already installed (skip the check)
  * @return {Promise} A promise resolved with all of the npmi results for each extensions
  */
-em.installExtensions = function(extensions, force) {
+ext_man.installExtensions = function(extensions, force) {
     debug('installExtensions');
 
     var promises = [],
@@ -45,39 +34,12 @@ em.installExtensions = function(extensions, force) {
 };
 
 /**
- * Add a new extensions to this frame.
- *
- * Installs the extensions, and if that's successful then adds it to the extensions list.
- *
- * TODO: deal with conflicting versions of extensions
- *
- * @param  {String} package_name NPM package name
- * @param  {String} version      NPM package version (or repo URL for extensions not in NPM)
- * @return {Promise} A promise resolving with the result from npmi
- */
-em.addExtension = function(package_name, version) {
-    debug('addExtension', package_name, version);
-    return new Promise((resolve, reject) => {
-        em.installExtension(package_name, version)
-            .then(function() {
-                em.extensions[package_name] = version;
-                config.save();
-                resolve(package_name);
-            })
-            .catch(function(err) {
-                debug(err);
-                reject(err);
-            });
-    });
-};
-
-/**
  * Initialize extensions.
  *
  * @param  {String} extensions
  * @param  {Object} ofExtensionApi An interface to the frame provided to each extensions
  */
-em.initExtensions = function(extensions, ofExtensionApi) {
+ext_man.initExtensions = function(extensions, ofExtensionApi) {
     debug('initExtensions', extensions);
     var promises = [],
         key;
@@ -97,7 +59,7 @@ em.initExtensions = function(extensions, ofExtensionApi) {
 };
 
 /**
- * Install a single extensions via NPM
+ * Install a single extension via NPM
  *
  * Uses machine's npm as a child_process so that we don't have to depend on the npm package.
  *
@@ -105,7 +67,7 @@ em.initExtensions = function(extensions, ofExtensionApi) {
  *
  * @param  {String} package_name NPM package name
  * @param  {String} version      NPM package version (or repo URL for extensions not in NPM)
- * @param {Boolean} force Install the extensions even if it's already installed (skip the check)
+ * @param {Boolean} force Install the extension even if it's already installed (skip the check)
  * @return {Promise} A promise resolving with the package_name
  */
 function _installExtension(package_name, version, force) {
@@ -140,17 +102,17 @@ function _installExtension(package_name, version, force) {
 }
 
 // public exposure
-em.installExtension = _installExtension;
+ext_man.installExtension = _installExtension;
 
 /**
- * Removes a single extensions by removing it from the npm package.
+ * Rext_manoves a single extensions by rext_manoving it from the npm package.
  *
  * @param  {String} package_name NPM package name
  * @return {Promise} A promise resolving with the package_name
  */
-function _removeExtension(package_name) {
-    debug('removeExtension', package_name);
-    var cmd = 'npm remove -g ' + package_name;
+function _rext_manoveExtension(package_name) {
+    debug('rext_manoveExtension', package_name);
+    var cmd = 'npm rext_manove -g ' + package_name;
     cmd += ' --save';
     return new Promise((resolve, reject) => {
         _runNpmCommand(cmd).then(function() {
@@ -160,7 +122,7 @@ function _removeExtension(package_name) {
 }
 
 // public exposure
-em.uninstallExtension = _removeExtension;
+ext_man.uninstallExtension = _rext_manoveExtension;
 
 /**
  * Check whether a extension is already installed.
@@ -214,7 +176,7 @@ function _initExtension(extensions_name, ofExtensionApi) {
             extensions._init(ofExtensionApi);
             resolve(extensions);
         } catch (e) {
-            // problem trying to require extensions
+            // problext_man trying to require extensions
             debug('ERROR - ', e);
             reject(e);
         }

--- a/test/extension-manager.spec.js
+++ b/test/extension-manager.spec.js
@@ -1,21 +1,17 @@
 var assert = require('assert'),
     sinon = require('sinon'),
     npm = require('npm'),
-    pm = require('../plugin-manager');
+    ext_man = require('../src/extension-manager');
 
-var config = {
-    ofrc: {
-        frame: {
-            plugins: {
-                "lodash": "4.0.0"
-            }
+var frame = {
+    state: {
+        extensions: {
+            "lodash": "4.0.0"
         }
-    },
-    save: sinon.spy()
-};
+    }
+}
 
 before(function() {
-    pm.init(config);
 });
 
 afterEach(function(done) {
@@ -37,17 +33,10 @@ afterEach(function(done) {
     });
 });
 
-describe('init', function() {
-    // it('should store a local reference to the plugin list', function(done) {
-    //     assert.equal(pm.plugins["lodash"], "4.0.0");
-    //     done();
-    // });
-});
-
-describe('installPlugin', function() {
+describe('installExtension', function() {
     this.timeout(0);
     it('should install an npm package with a version specified', function(done) {
-        pm.installPlugin("lodash", "4.0.0")
+        ext_man.installExtension("lodash", "4.0.0")
             .then(function() {
                 npm.load({
                     logLevel: 'silent'
@@ -70,7 +59,7 @@ describe('installPlugin', function() {
     });
 
     it('should install an npm package without a version specified', function(done) {
-        pm.installPlugin("lodash")
+        ext_man.installExtension("lodash")
             .then(function() {
                 npm.load({
                     logLevel: 'silent'
@@ -94,7 +83,7 @@ describe('installPlugin', function() {
 
     it('should fail to install an npm package that does not exist', function(done) {
 
-        pm.installPlugin("openframe-this-is-not-real")
+        ext_man.installExtension("openframe-this-is-not-real")
             .catch(function(err) {
                 done();
             });
@@ -103,10 +92,10 @@ describe('installPlugin', function() {
 });
 
 
-describe('installPlugins', function() {
+describe('installExtensions', function() {
     this.timeout(0);
-    it('should install all plugins passed in an npm dependency object', function(done) {
-        pm.installPlugins(config)
+    it('should install all extensions passed in an npm dependency object', function(done) {
+        ext_man.installExtensions(frame.state.extensions)
             .then(function() {
                 npm.load({
                     logLevel: 'silent'
@@ -124,42 +113,6 @@ describe('installPlugins', function() {
                     });
                 });
 
-            });
-    });
-});
-
-describe('addPlugin', function() {
-    this.timeout(0);
-    it('should add and install a new plugin', function(done) {
-        pm.addPlugin("lodash")
-            .then(function() {
-                npm.load({
-                    logLevel: 'silent'
-                }, function(err) {
-                    if (err) {
-                        console.error(err);
-                        return;
-                    }
-                    npm.commands.ls(['lodash'], function(err, data) {
-                        if (err) {
-                            console.error(err);
-                        }
-                        // openframe-keystroke found
-                        assert.equal(data._found, 1);
-
-                        // check that the config was saved
-                        assert(config.save.called);
-                        done();
-                    });
-                });
-
-            });
-    });
-
-    it('should fail to add and install a non existent plugin', function(done) {
-        pm.addPlugin("openframe-this-is-not-real")
-            .catch(function(err) {
-                done();
             });
     });
 });


### PR DESCRIPTION
This PR fixes #35 and is a response to the "work needed" tag on that issue. It is a continuation of some previous refactoring work which renamed plugins to extensions. There are a few changes to variable names and documentation. Some deprecated functions are now removed. More importantly, the related tests now pass.