### PR TITLE
Promise start command

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -415,15 +415,28 @@ function _startArt(new_format, new_artwork) {
         // construct the command dynamically...
         var options = new_artwork.options || {};
         _command = _command.call(new_format, options, tokens);
+        
+        Promise.resolve(_command).then(function(value) {
+          _command = value
+          
+          return replaceTokensAndStart()
+        })
+        
     }
-    var command = _replaceTokens(_command, tokens);
+    else {
+      return replaceTokensAndStart()
+    } 
+    
+    function replaceTokensAndStart() {
+      var command = _replaceTokens(_command, tokens);
 
-    return new Promise(function(resolve, reject) {
-        // TODO: proc_man.startProcess doesn't return Promise
-        // can we know when the process is ready without ipc?
-        proc_man.startProcess(command);
-        resolve();
-    });
+      return new Promise(function(resolve, reject) {
+          // TODO: proc_man.startProcess doesn't return Promise
+          // can we know when the process is ready without ipc?
+          proc_man.startProcess(command);
+          resolve();
+      }); 
+    }
 }
 
 /**

--- a/src/controller.js
+++ b/src/controller.js
@@ -416,6 +416,7 @@ function _startArt(new_format, new_artwork) {
         var options = new_artwork.options || {};
         _command = _command.call(new_format, options, tokens);
         
+        // start_command of the extension can return either Promise or a value, both is okay.
         return Promise.resolve(_command).then(function(value) {
           return new Promise(function(resolve, reject) {
             _command = value

--- a/src/controller.js
+++ b/src/controller.js
@@ -416,10 +416,12 @@ function _startArt(new_format, new_artwork) {
         var options = new_artwork.options || {};
         _command = _command.call(new_format, options, tokens);
         
-        Promise.resolve(_command).then(function(value) {
-          _command = value
-          
-          return replaceTokensAndStart()
+        return Promise.resolve(_command).then(function(value) {
+          return new Promise(function(resolve, reject) {
+            _command = value
+            
+            resolve(replaceTokensAndStart())
+          })
         })
         
     }


### PR DESCRIPTION
To be able to do async tasks when loading/starting an extension, we need promises. Specifically, the Processing extension needs to unzip the artwork and copy a few files first, which can take some time.

The code is working for the most part, but unfortunately, there is a problem. The artwork is loading, but there is an error `(node:5239) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'then' of undefined`. And the artwork doesn't close anymore when switching to a different artwork. I believe I'm not returning the Promise in line 422 of `controller.js`. Unfortunately, I don't have an idea of how to do that.

This is the extension counterpart:
https://github.com/jvolker/Openframe-Processing/commits/promiseUnzip

Any idea @jmwohl and @jeremydouglass?

Thanks.