### PR TITLE
Fix pubsub availability issue with extensions

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -279,12 +279,12 @@ fc.connect = function(userId) {
         // XXX - POTENTIAL BUG - catch extension init error separately, otherwise a new frame is created.
         frame
             .fetch()
+            .then(readyToConnect)
             .then(function() {
                 debug('ready to init...');
                 // initExtensions now always resolves, is never rejected
                 return ext_man.initExtensions(frame.state.extensions, fc.extensionApi);
-            })
-            .then(readyToConnect)
+            })          
             .catch(function(err) {
                 debug(err);
                 fc.registerNewFrame(userId)


### PR DESCRIPTION
When attempting to subscribe to the pubsub stream, I noticed an issue: this.pubsub would always be undefined. It seems this is because the pubsub service is enabled after the extensions are started. This pull request swaps the load order around, so that pubsub works for extensions.